### PR TITLE
Delete service workers on every page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,10 +2,14 @@ import React from "react";
 import App, { Container } from "next/app";
 
 import Layout from "../components/Layout";
+import { deleteServiceWorkers } from "../utils/offline";
 
-import "./index.css"
+import "./index.css";
 
 export default class MyApp extends App {
+  componentDidMount() {
+    deleteServiceWorkers();
+  }
   render() {
     const { Component, pageProps } = this.props;
     return (

--- a/utils/offline.js
+++ b/utils/offline.js
@@ -1,0 +1,7 @@
+export const deleteServiceWorkers = () => {
+  navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    for (let registration of registrations) {
+      registration.unregister();
+    }
+  });
+};


### PR DESCRIPTION
Previous version of GraphQL College registered a service worker.

This service worker is breaking the new version, so we uninstall it.